### PR TITLE
[hm] Int & Deriv Patch redone

### DIFF
--- a/arduino/heatermeter/grillpid.h
+++ b/arduino/heatermeter/grillpid.h
@@ -143,6 +143,7 @@ class GrillPid
 {
 private:
   unsigned char _pidOutput;
+  float _derivFilt; // derivative filter
   unsigned long _lastWorkMillis;
   unsigned char _pitStartRecover;
   int _setPoint;

--- a/arduino/heatermeter/grillpid_conf.h
+++ b/arduino/heatermeter/grillpid_conf.h
@@ -19,6 +19,13 @@
 // Use oversample/decimation to increase ADC resolution to 2^(10+n) bits n=[0..4]
 #define TEMP_OVERSAMPLE_BITS 4
 
+// PID Controls
+// Error feed limit for Integrator
+#define INTEGRAL_STARTUP_RATE 20
+// Needs to be less than TEMPPROBE_AVG_SMOOTH but high enough to average out
+// the temp noise that gets amplified by Kd. 
+#define DERIV_FILTER_SMOOTH (1.0f/15.0f)
+
 // The time (ms) of the measurement period
 #define TEMP_MEASURE_PERIOD 1000
 // Number of times the ouput is adusted over TEMP_MEASURE_PERIOD


### PR DESCRIPTION
Decided that Integrators job was to help get to the setpoint. As such
limited the error it can see. Feed rate is currently a #define but have
pondered using the lid reset percentage as being the limit of a "control
zone" and going for half that value

Derivative I found that just a simple filter on the output provided
extreme smoothing which is apparently how some commercial controllers
deal with it.

Deriv filter also enables the ability to for the controller to
automatically choose when to come out of lid open time. (not in this patch)

With this change can eliminate the halfing of Integrator at setpoint(not in this patch)
