### PR TITLE
Fan offset option

### DIFF
--- a/arduino/heatermeter/grillpid.cpp
+++ b/arduino/heatermeter/grillpid.cpp
@@ -572,6 +572,9 @@ inline void GrillPid::commitServoOutput(void)
   else
     output = _pidOutput;
 
+  //Make sure the servo doesn't get anything over 100 when PIDFLAG_SERVO_THEN_FAN is in use
+  output = constrain(output,0,100);    
+    
   if (bit_is_set(_outputFlags, PIDFLAG_INVERT_SERVO))
     output = 100 - output;
 
@@ -650,7 +653,8 @@ void GrillPid::status(void) const
     Serial_csv();
   }
 
-  SerialX.print(getPidOutput(), DEC);
+  //Limit PidOutput display for SERVO_THEN_FAN mode. Saves redoing graphs.
+  SerialX.print(constrain(getPidOutput(),0,100), DEC);
   Serial_csv();
   SerialX.print((int)PidOutputAvg, DEC);
   Serial_csv();

--- a/arduino/heatermeter/grillpid.cpp
+++ b/arduino/heatermeter/grillpid.cpp
@@ -764,6 +764,7 @@ void GrillPid::setUnits(char units)
 
 void GrillPid::setFanOffset(unsigned char value)
 {
+  _fanOffset = value;
   // Prevent out of range from user input or firmware upgrade
   if ( _fanOffset > 100) {
     _fanOffset = 0;

--- a/arduino/heatermeter/grillpid.cpp
+++ b/arduino/heatermeter/grillpid.cpp
@@ -442,7 +442,7 @@ inline void GrillPid::calcPidOutput(void)
 
   // IIIII = fan speed percent per degree of accumulated error
   // anti-windup: Make sure we only adjust the I term while inside the proportional control range
-  if ((error > 0 && lastOutput < 100) || (error < 0 && lastOutput > 0))
+  if ((error > 0 && lastOutput < _maxPidOutput) || (error < 0 && lastOutput > 0))
     _pidCurrent[PIDI] += Pid[PIDI] * error;
 
   // DDDDD = fan speed percent per degree of change over TEMPPROBE_AVG_SMOOTH period
@@ -451,7 +451,7 @@ inline void GrillPid::calcPidOutput(void)
   _pidCurrent[PIDB] = Pid[PIDB];
 
   int control = _pidCurrent[PIDB] + _pidCurrent[PIDP] + _pidCurrent[PIDI] + _pidCurrent[PIDD];
-  _pidOutput = constrain(control, 0, 100);
+  _pidOutput = constrain(control, 0, _maxPidOutput);
 }
 
 void GrillPid::adjustFeedbackVoltage(void)
@@ -507,7 +507,14 @@ inline void GrillPid::commitFanOutput(void)
     else
       max = _maxFanSpeed;
 
-    _fanSpeed = (unsigned int)_pidOutput * max / 100;
+    //Make sure _fanSpeed only sees 0 - 100 and does nothing till until _pidOutput
+    //is in the overlap region or higher
+    if  (_pidOutput > _fanOffset ) {
+      _fanSpeed = (unsigned int)(_pidOutput - _fanOffset) * max / 100;
+    }
+    else {
+      _fanSpeed = 0;
+    }
   }
 
   /* For anything above _minFanSpeed, do a nomal PWM write.
@@ -619,7 +626,7 @@ void GrillPid::setSetPoint(int value)
 void GrillPid::setPidOutput(int value)
 {
   _manualOutputMode = true;
-  _pidOutput = constrain(value, 0, 100);
+  _pidOutput = constrain(value, 0, _maxPidOutput);
   LidOpenResumeCountdown = 0;
 }
 
@@ -707,7 +714,7 @@ boolean GrillPid::doWork(void)
     // Note that the code assumes we're not currently counting down
     else if (isPitTempReached() && 
       (((_setPoint-pitTemp)*100/_setPoint) >= (int)LidOpenOffset) &&
-      ((int)PidOutputAvg < 90))
+      ((int)PidOutputAvg < (90*_maxPidOutput)/100))
     {
       resetLidOpenResumeCountdown();
     }
@@ -749,4 +756,19 @@ void GrillPid::setUnits(char units)
       _units = units;
       break;
   }
+}
+
+void GrillPid::setFanOffset(unsigned char value)
+{
+  // Prevent out of range from user input or firmware upgrade
+  if ( _fanOffset > 100) {
+    _fanOffset = 0;
+  }
+  _maxPidOutput = 100 + _fanOffset;
+#if 0
+  /* Make sure no pidflag modes are in operation if offset is being set */
+  if (_fanOffset) {
+    _outputFlags &= ~(1<<PIDFLAG_FAN_ONLY_MAX | 1<<PIDFLAG_SERVO_ANY_MAX);
+  }
+#endif
 }

--- a/arduino/heatermeter/grillpid.h
+++ b/arduino/heatermeter/grillpid.h
@@ -143,6 +143,7 @@ class GrillPid
 {
 private:
   unsigned char _pidOutput;
+  unsigned char _maxPidOutput;
   unsigned long _lastWorkMillis;
   unsigned char _pitStartRecover;
   int _setPoint;
@@ -160,6 +161,7 @@ private:
   unsigned char _maxServoPos;
   unsigned char _minServoPos;
   unsigned char _outputFlags;
+  unsigned char _fanOffset;
 
   // Current fan speed (percent)
   unsigned char _fanSpeed;
@@ -209,6 +211,8 @@ public:
   // The minimum fan speed percent before converting to "long PID" (SRTP) mode
   unsigned char getMinFanSpeed(void) const { return _minFanSpeed; }
   void setMinFanSpeed(unsigned char value) { _minFanSpeed = constrain(value, 0, 100); }
+  unsigned char getFanOffset(void) const { return _fanOffset; }
+  void setFanOffset(unsigned char value);
 
   // Servo timing
   // The duration (in 10x usec) for the maxium servo position

--- a/arduino/heatermeter/hmcore.cpp
+++ b/arduino/heatermeter/hmcore.cpp
@@ -60,6 +60,9 @@ static const struct __eeprom_data {
   unsigned char lcdBacklight; // in PWM (max 100)
 #ifdef HEATERMETER_RFM12
   unsigned char rfMap[TEMP_COUNT];
+#else
+  /* Added to keep eeprom memory structure intact on already in use avr */
+  unsigned char open_spot[TEMP_COUNT];
 #endif
   char pidUnits;
   unsigned char minFanSpeed;  // in percent
@@ -82,6 +85,8 @@ static const struct __eeprom_data {
   50,   // lcd backlight (%)
 #ifdef HEATERMETER_RFM12
   { RFSOURCEID_ANY, RFSOURCEID_ANY, RFSOURCEID_ANY, RFSOURCEID_ANY },  // rfMap
+#else
+  { 0, 0, 0, 0}, // unused
 #endif
   'F',  // Units
   0,    // min fan speed

--- a/arduino/heatermeter/hmcore.cpp
+++ b/arduino/heatermeter/hmcore.cpp
@@ -70,6 +70,7 @@ static const struct __eeprom_data {
   unsigned char ledConf[LED_COUNT];
   unsigned char minServoPos;  // in 10us
   unsigned char maxServoPos;  // in 10us
+  unsigned char fanOffset;
 } DEFAULT_CONFIG[] PROGMEM = {
  {
   EEPROM_MAGIC,  // magic
@@ -90,7 +91,8 @@ static const struct __eeprom_data {
   100, // max startup fan speed
   { LEDSTIMULUS_FanMax, LEDSTIMULUS_LidOpen, LEDSTIMULUS_FanOn, LEDSTIMULUS_Off },
   150-50, // min servo pos = 1000us
-  150+50  // max servo pos = 2000us
+  150+50, // max servo pos = 2000us
+  0   // fanOffset = 0, fan and server can run in parallel depending on PIDOUTPUTFLAGS
 }
 };
 
@@ -279,6 +281,12 @@ static void storeMaxFanSpeed(unsigned char maxFanSpeed)
 {
   pid.setMaxFanSpeed(maxFanSpeed);
   config_store_byte(maxFanSpeed, pid.getMaxFanSpeed());
+}
+
+static void storeFanOffset(unsigned char fanOffset)
+{
+  pid.setFanOffset(fanOffset);
+  config_store_byte(fanOffset, pid.getFanOffset());
 }
 
 static void storeMaxStartupFanSpeed(unsigned char maxStartupFanSpeed)
@@ -755,6 +763,8 @@ static void reportFanParams(void)
   SerialX.print(pid.getOutputFlags(), DEC);
   Serial_csv();
   SerialX.print(pid.getMaxStartupFanSpeed(), DEC);
+  Serial_csv();
+  SerialX.print(pid.getFanOffset(), DEC);
   Serial_nl();
 }
 
@@ -876,7 +886,9 @@ static void storeFanParams(unsigned char idx, int val)
       break;
     case 5:
       storeMaxStartupFanSpeed(val);
-      break;
+    case 6:
+      storeFanOffset(val);
+    break;
   }
 }
 
@@ -1099,7 +1111,8 @@ static void eepromLoadBaseConfig(unsigned char forceDefault)
   g_HomeDisplayMode = config.base.homeDisplayMode;
   pid.setMinServoPos(config.base.minServoPos);
   pid.setMaxServoPos(config.base.maxServoPos);
-
+  pid.setFanOffset(config.base.fanOffset);
+  
   for (unsigned char led = 0; led<LED_COUNT; ++led)
     ledmanager.setAssignment(led, config.base.ledConf[led]);
 }

--- a/openwrt/package/linkmeter/luasrc/lucid/linkmeterd.lua
+++ b/openwrt/package/linkmeter/luasrc/lucid/linkmeterd.lua
@@ -238,7 +238,7 @@ local function segLidParams(line)
 end
 
 local function segFanParams(line)
-  return segConfig(line, {"fmin", "fmax", "smin", "smax", "oflag", "fsmax"}, true)
+  return segConfig(line, {"fmin", "fmax", "smin", "smax", "oflag", "fsmax", "foffset"}, true)
 end
 
 local function segProbeCoeffs(line)

--- a/openwrt/package/linkmeter/luasrc/view/linkmeter/conf.htm
+++ b/openwrt/package/linkmeter/luasrc/view/linkmeter/conf.htm
@@ -446,7 +446,7 @@ function updateConfigUrl(divname, h)
   csvItems(h, aValues, "po", ["po0", "po1", "po2", "po3"]);
   csvItems(h, aValues, "al", ["pall0", "palh0", "pall1", "palh1",
     "pall2", "palh2", "pall3", "palh3"]);
-  csvItems(h, aValues, "fn", ["fmin", "fmax", "smin", "smax", "oflag", "fsmax"]);
+  csvItems(h, aValues, "fn", ["fmin", "fmax", "smin", "smax", "oflag", "fsmax", "foffset"]);
   for (var i=0; i<4; ++i)
     csvItems(h, aValues, "pc"+i, ["pca"+i, "pcb"+i, "pcc"+i, "pcr"+i, 
       function () { return getProbeTypeForSend(h, i); } ]);
@@ -647,6 +647,7 @@ time they are restarted.</div>
       <input type="text" maxlength="3" id="fsmax" style="width: 2em;"/>%
     <label><input type="checkbox" id="oflag0"/> Invert output</label>
     <label><input type="checkbox" id="oflag2"/> On at max only</label>
+    <input type="text" maxlength="3" id="foffset" style="width: 2em;"/>% fan offset
   </div>
   <div class="cbi-value cbi-value-last">
     Servo pulse duration


### PR DESCRIPTION
I'll start off with I don't expect this to be the final form.

What I have tried to accomplish is allowing the servo to do natural convection but the fan can be brought in a linear fashion if more is needed. This has allowed me to walk away and not be as worried if I have the top damper setting correct. It really saved me over Thanksgiving as I got involved in a football game. Half time I noticed the fan was running at 20% output. Opened the top damper some more over half-time and turkey came out great

Considered making the fan and servo go end to end. So it would be 100 points for servo, then 100 for fan. Would be easy to just divide by 2 where readouts are needed. Found myself wanting some overlap and could see others wanting it as well. Especially the guy with a damper on the output and fan on the input.

I tried to address what happens when the firmware gets flashed and first use would pull a 255 from a new eeprom position. Tried to make the _pidOutput split out in a logical fashion when status is sent to linkmeter. I still like having the fan as a separate item on the graph. I like data but I know that can be overwhelming to some. Probably would create questions.

The print out on the LCD doesn't bother me but I'm worried it could confuse some when it's readying more than 100. Pondered if it could do something like 1-100 as normal. and then just output the fanspeed with an * ( such as 90* or 100*). Really didn't want to go into the menu system as that's an a huge amount of callbacks going on there.

I really think there needs to be a lockout to prevent a user from using all the alternate modes. I added it to the setFanoffset then turned it off with a compile directive. Perhaps someone has a reason for needing to activate several at once. From reading the forums this project ends up in places that are unexpected.

This uses 146 bytes of additional flash compared to current line

Tried to attach a screenshot of last cook. Time 14:20 I noticed the fan was having to pump. Went out and opened the top damper ( it was raining, blowing, and I had unexpected company if you are wondering how I it took me hours to noticed). Bright blue line is the fan
![ribs-hm-01-17-2015-p3 5-i006-d12](https://cloud.githubusercontent.com/assets/9030000/5929344/ddae2396-a650-11e4-8e95-c58f133acc1b.PNG)
