### PR TITLE
[wrt] update opkg package source

### DIFF
--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -55,6 +55,7 @@ if [ "$TARGET" = "BCM2708" ] ; then
   patch -N -p0 -d $WRT_PATH < patches/229-netifd-add-hostname.patch
   patch -N -p0 -d $WRT_PATH < patches/230-hotplug2-source.patch
   patch -N -p0 -d $WRT_PATH < patches/231-clearsilver-utf8.patch
+  patch -N -p0 -d $WRT_PATH < patches/233-opkg-source.patch
   cp patches/06??-rpi-patches-*.patch \
     $WRT_PATH/target/linux/brcm2708/patches-3.3/.
 fi

--- a/openwrt/patches/233-opkg-source.patch
+++ b/openwrt/patches/233-opkg-source.patch
@@ -1,0 +1,23 @@
+--- package/opkg/Makefile.orig	2016-05-31 19:22:58.267086485 +0000
++++ package/opkg/Makefile	2016-05-31 19:24:13.287087651 +0000
+@@ -9,15 +9,16 @@
+ include $(INCLUDE_DIR)/version.mk
+ 
+ PKG_NAME:=opkg
+-PKG_REV:=618
++PKG_REV:=9c97d5ecd795709c8584e972bfdf3aee3a5b846d
+ PKG_VERSION:=$(PKG_REV)
+-PKG_RELEASE:=3
++PKG_RELEASE:=7
+ 
+-PKG_SOURCE_PROTO:=svn
++PKG_SOURCE_PROTO:=git
+ PKG_SOURCE_VERSION:=$(PKG_REV)
+ PKG_SOURCE_SUBDIR:=opkg-$(PKG_VERSION)
+-PKG_SOURCE_URL:=http://opkg.googlecode.com/svn/trunk/
++PKG_SOURCE_URL:=http://git.yoctoproject.org/git/opkg
+ PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.gz
++PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+ PKG_FIXUP:=autoreconf
+ PKG_REMOVE_FILES = autogen.sh aclocal.m4
+ 


### PR DESCRIPTION
The svn repo at http://opkg.googlecode.com/svn/trunk/ seems to be gone now. I've switched the repo to the official opkg git repo, referencing the commit id to match the SVN tag.