### PR TITLE
Arduino was mis-spelled in README.  Corrected

### DIFF
--- a/README
+++ b/README
@@ -21,6 +21,6 @@ t |    +-------+    |
   
 Source Layout
 openwrt/* - Files you'd push to your router for LinkMeter
-arduinio/* - AVR source code for upload to your Arduino board
+arduino/* - AVR source code for upload to your Arduino board
 pebble/* - Source to the Pebble app
 tools/* - Miscellaneous scripts and .NET apps


### PR DESCRIPTION
Just a simple spelling update.  Hope to help out in the future!