### PR TITLE
[hm] Change REMOTE_BASE to use https

### DIFF
--- a/openwrt/package/linkmeter/luasrc/luci/view/linkmeter/fw.htm
+++ b/openwrt/package/linkmeter/luasrc/luci/view/linkmeter/fw.htm
@@ -2,7 +2,7 @@
 <script language="javascript" src="<%=resource%>/js/jquery-all.js" type="text/javascript"></script>
 <script type="text/javascript">//<![CDATA[
   var RSTYLES = [ "cbi-rowstyle-1", "cbi-rowstyle-2" ];
-  var REMOTE_BASE = 'http://heatermeter.com/devel/';
+  var REMOTE_BASE = 'https://heatermeter.com/devel/';
   var BUNDLED_FILES = [
 <%
   for f in nixio.fs.glob("/lib/firmware/*.hex") do


### PR DESCRIPTION
HTTPS users aren't able to load the remote firmware repo due to mixed content errors. Loading the repo over HTTPS by default will fix this for HTTPS users and won't change anything for HTTP users.